### PR TITLE
fix(search): only retrieve needed attributes

### DIFF
--- a/lib/packages-index.js
+++ b/lib/packages-index.js
@@ -29,6 +29,7 @@ export default class {
             'license',
             'version'
           ],
+          attributesToHighlight: [],
           analyticsTags: [`atom-${pluginName}`]
         },
         (error, response) => {

--- a/lib/packages-index.js
+++ b/lib/packages-index.js
@@ -22,6 +22,13 @@ export default class {
       this.index.search(
         {
           query,
+          attributesToRetrieve: [
+            'name',
+            'description',
+            'humanDownloadsLast30Days',
+            'license',
+            'version'
+          ],
           analyticsTags: [`atom-${pluginName}`]
         },
         (error, response) => {


### PR DESCRIPTION
This is necessary because the index has _big_ records like the `readme`, which isn't displayed here at all

I didn't test it though, so please test it thoroughly before merging 