### PR TITLE
chore/referer/stats

### DIFF
--- a/lib/packages-index.js
+++ b/lib/packages-index.js
@@ -14,6 +14,7 @@ export default class {
     client.addAlgoliaAgent(
       `atom-autocomplete-module-import (${pluginVersion})`
     );
+    client.setExtraHeader('referer', 'https://github.com/algolia/atom-autocomplete-module-import/');
     this.index = client.initIndex(ALGOLIA_INDEX_NAME);
   }
 


### PR DESCRIPTION
Add a referer to https://github.com/algolia/atom-autocomplete-module-import/ so that the Yarn index will be able to compute usage compared to other websites/app (jsDelivr, Yarn website).

This is different from knowing the user agent because we don't care about the version and we really want to compare apps between then, no matter the technical implementation (react, js client..)